### PR TITLE
Implemented ConciseCard plugin with dynamic category and tag filters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN nohup bash -c "sinopia &" && sleep 2 \
     && cd /app/superset-ui/plugins/legacy-preset-chart-nvd3 && npm publish \
     && cd /app/superset-ui/plugins/plugin-chart-echarts && npm publish \
     && cd /app/superset-ui/plugins/plugin-chart-stylo-pie-table && npm publish \
+    && cd /app/superset-ui/plugins/plugin-chart-concise-card && npm publish \
     && /frontend-mem-nag.sh \
     && cd /app/superset-frontend \
     && npm ci

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -83,7 +83,6 @@ import { PivotTableChartPlugin as PivotTableChartPluginV2 } from '@superset-ui/p
 import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
 import TimeTableChartPlugin from '../TimeTable/TimeTableChartPlugin';
 import { ConciseCardChartPlugin } from '@superset-ui/plugin-chart-concise-card';
-import { StyloPieTableChartPlugin } from '@superset-ui/plugin-chart-stylo-pie-table';
 
 export default class MainPreset extends Preset {
   constructor() {

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -82,6 +82,7 @@ import {
 import { PivotTableChartPlugin as PivotTableChartPluginV2 } from '@superset-ui/plugin-chart-pivot-table';
 import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
 import TimeTableChartPlugin from '../TimeTable/TimeTableChartPlugin';
+import { ConciseCardChartPlugin } from '@superset-ui/plugin-chart-concise-card';
 import { StyloPieTableChartPlugin } from '@superset-ui/plugin-chart-stylo-pie-table';
 
 export default class MainPreset extends Preset {
@@ -168,6 +169,7 @@ export default class MainPreset extends Preset {
         new TimeGrainFilterPlugin().configure({ key: 'filter_timegrain' }),
         new EchartsTreeChartPlugin().configure({ key: 'tree_chart' }),
 	      new StyloPieTableChartPlugin().configure({ key: 'stylo-pie-table' }),
+        new ConciseCardChartPlugin().configure({key: 'stylo-concise-card'}),
         ...experimentalplugins,
       ],
     });


### PR DESCRIPTION
Implemented custom viz plugin "Concise Card".


### SUMMARY
It displays metrics in concise way. And includes dynamic filter dropdowns for "category" and "tag" fields.

### TESTING INSTRUCTIONS
Create new chart with type "Concise card"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
