### PR TITLE
add Drilldown functionality to table chart

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/DrillDown.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/DrillDown.ts
@@ -29,7 +29,7 @@ export default class DrillDown {
     };
   }
 
-  static drillDown(value: DrillDownType, selectValue: string): DrillDownType {
+  static drillDown(value: DrillDownType, selectValue: string | Object): DrillDownType {
     const idx = value.currentIdx;
     const len = value.hierarchy.length;
 
@@ -40,13 +40,16 @@ export default class DrillDown {
         filters: [],
       };
     }
+
+    const selection = (selectValue instanceof(Object)) ? selectValue[value.hierarchy[idx]] : selectValue;
+
     return {
       hierarchy: value.hierarchy,
       currentIdx: idx + 1,
       filters: value.filters.concat({
         col: value.hierarchy[idx],
         op: 'IN',
-        val: [selectValue],
+        val: [selection],
       }),
     };
   }

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -63,6 +63,7 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   sticky?: boolean;
   rowCount: number;
   wrapperRef?: MutableRefObject<HTMLDivElement>;
+  rowClick?: (data: D) => void;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -94,6 +95,7 @@ export default function DataTable<D extends object>({
   hooks,
   serverPagination,
   wrapperRef: userWrapperRef,
+  rowClick,
   ...moreUseTableOptions
 }: DataTableProps<D>): JSX.Element {
   const tableHooks: PluginHook<D>[] = [
@@ -234,7 +236,7 @@ export default function DataTable<D extends object>({
             prepareRow(row);
             const { key: rowKey, ...rowProps } = row.getRowProps();
             return (
-              <tr key={rowKey || row.id} {...rowProps}>
+              <tr key={rowKey || row.id} {...rowProps} onClick={() => { rowClick?rowClick(row.original):null }}>
                 {row.cells.map(cell =>
                   cell.render('Cell', { key: cell.column.id }),
                 )}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -29,6 +29,7 @@ import { FaSortUp as FaSortAsc } from '@react-icons/all-files/fa/FaSortUp';
 import {
   DataRecord,
   DataRecordValue,
+  DrillDown,
   DTTM_ALIAS,
   ensureIsArray,
   GenericDataType,
@@ -188,6 +189,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     filters,
     sticky = true, // whether to use sticky header
     columnColorFormatters,
+    ownState,
+    drillDown,
   } = props;
   const timestampFormatter = useCallback(
     value => getTimeFormatterForGranularity(timeGrain)(value),
@@ -474,6 +477,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     updateExternalFormData(setDataMask, pageNumber, pageSize);
   };
 
+  const rowDrillDown = (data: D) => {
+    if (drillDown && ownState?.drilldown) {
+      const drilldown = DrillDown.drillDown(ownState.drilldown, data);
+      
+      setDataMask({
+        extraFormData: { filters: DrillDown.getFilters(drilldown, []) },
+        filterState: { value: drilldown.hierarchy },
+        ownState: { drilldown }
+      });
+    }
+  };
+
   return (
     <Styles>
       <DataTable<D>
@@ -497,6 +512,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         selectPageSize={pageSize !== null && SelectPageSize}
         // not in use in Superset, but needed for unit tests
         sticky={sticky}
+        rowClick={rowDrillDown}
       />
     </Styles>
   );

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -346,6 +346,23 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_DRILL_DOWN)
+        ? [
+            {
+              name: 'drillDown',
+              config: {
+                type: 'DrillDownControl',
+                default: false,
+                label: t('Enable drill down'),
+                description: t('Columns as hierarchy.'),
+                mapStateToProps: ({ form_data }) => ({
+                  chartId: form_data?.slice_id || 0,
+                  columns: form_data.groupby,
+                }),
+              },
+            },
+          ]
+        : [],
         [
           {
             name: 'show_totals',

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -19,6 +19,7 @@
 import memoizeOne from 'memoize-one';
 import {
   DataRecord,
+  DrillDown,
   extractTimegrain,
   GenericDataType,
   getMetricLabel,
@@ -40,6 +41,7 @@ import {
   TableChartProps,
   TableChartTransformedProps,
 } from './types';
+import { OwnState } from '.';
 
 const { PERCENT_3_POINT } = NumberFormats;
 const { DATABASE_DATETIME } = TimeFormats;
@@ -215,6 +217,7 @@ const transformProps = (
     query_mode: queryMode,
     show_totals: showTotals,
     conditional_formatting: conditionalFormatting,
+    drillDown,
   } = formData;
   const timeGrain = extractTimegrain(formData);
 
@@ -238,6 +241,8 @@ const transformProps = (
       : undefined;
   const columnColorFormatters =
     getColorFormatters(conditionalFormatting, data) ?? [];
+
+  const ownState: OwnState = chartProps.ownState;
 
   return {
     height,
@@ -265,6 +270,8 @@ const transformProps = (
     onChangeFilter,
     columnColorFormatters,
     timeGrain,
+    drillDown,
+    ownState
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -30,6 +30,8 @@ import {
   ChartDataResponseResult,
   QueryFormData,
   SetDataMaskHook,
+  DrillDownType,
+  JsonObject,
 } from '@superset-ui/core';
 import { ColorFormatters, ColumnConfig } from '@superset-ui/chart-controls';
 
@@ -47,6 +49,8 @@ export interface DataColumnMeta {
   isNumeric?: boolean;
   config?: ColumnConfig;
 }
+
+export type OwnState = JsonObject & { drilldown?: DrillDownType };
 
 export interface TableChartData {
   records: DataRecord[];
@@ -71,6 +75,7 @@ export type TableChartFormData = QueryFormData & {
   emit_filter?: boolean;
   time_grain_sqla?: TimeGranularity;
   column_config?: Record<string, ColumnConfig>;
+  drillDown: boolean;
 };
 
 export interface TableChartProps extends ChartProps {
@@ -109,6 +114,8 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   emitFilter?: boolean;
   onChangeFilter?: ChartProps['hooks']['onAddFilter'];
   columnColorFormatters?: ColorFormatters;
+  ownState: OwnState;
+  drillDown: boolean;
 }
 
 export default {};


### PR DESCRIPTION
### SUMMARY
this extends the drilldown functionality to rows of the table chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://askstylo.slack.com/files/U028GAL04PP/F030GFEMADC/_dev__chart_thing_-_google_chrome_2022-01-28_08-52-38-1.m4v

### TESTING INSTRUCTIONS
Create a new table chart.  Add some columns to the groupby field and an aggregate (sum of UIDs or something).  Tick "Enable Drill Down."  Observe clicking on rows will cycle through the hierarchy in the groupby field.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ x ] Required feature flags: DASHBOARD_DRILL_DOWN
- [ x ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
